### PR TITLE
Implement Upstream Private IP Blacklist policy [THREESCALE-732]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: quay.io/3scale/s2i-openresty-centos7:1.13.6.1-rover7
+    working_directory: /opt/app-root/apicast
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - rover-{{ arch }}-{{ checksum "Roverfile.lock" }}
+            - global-{{ arch }}-{{ .Branch }}
+            - global-{{ arch }}-master
+      - run: rover install
+      - save_cache:
+          key: rover-{{ arch }}-{{ checksum "Roverfile.lock" }}
+          paths:
+            - lua_modules
+      - restore_cache:
+          keys:
+            - cpanm-{{ arch }}-{{ checksum "cpanfile" }}
+            - global-{{ arch }}-{{ .Branch }}
+            - global-{{ arch }}-master
+      - run:
+          command: cpanm --notest --installdeps ./
+          shell: /usr/libexec/s2i/entrypoint
+      - save_cache:
+          key: cpanm-{{ arch }}-{{ checksum "cpanfile" }}
+          paths:
+            - ~/perl5
+      - run:
+          shell: /usr/libexec/s2i/entrypoint
+          name: rover exec prove
+          command: |
+            mkdir -p tmp/junit
+            rover exec prove --harness=TAP::Harness::JUnit \
+              $(circleci tests glob "t/**/*.t" |  circleci tests split --split-by=timings --timings-type=filename)
+          environment:
+            JUNIT_OUTPUT_FILE: tmp/junit/prove.xml
+            TEST_NGINX_ERROR_LOG: tmp/prove.log
+            TEST_NGINX_BINARY: openresty
+      - save_cache:
+          key: global-{{ arch }}-{{ .Branch }}
+          paths:
+            - lua_modules
+            - ~/perl5
+      - store_artifacts:
+          path: tmp
+          destination: tmp
+      - store_test_results:
+          path: tmp/junit

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+t/servroot
+lua_modules

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+[![CircleCI](https://circleci.com/gh/3scale/apicast-private-ip-blacklist-policy.svg?style=svg)](https://circleci.com/gh/3scale/apicast-private-ip-blacklist-policy)
+
+# APIcast Upstream Private IP Blacklist Policy
+
+This policy will blacklist private IP range and prevent connecting to
+those IP addresses as upstream server.
+
+
+## OpenShift
+
+To install this on OpenShift you can use provided template:
+
+```shell
+oc new-app -f openshift.yml --param AMP_RELEASE=2.2.0-GA
+```
+
+The template creates new ImageStream for images containing this policy.
+Then it creates two BuildConfigs: one for building an image to apicast-policy ImageStream
+and second one for creating new APIcast image copying just necessary code from that previous image.
+
+
+# License
+
+MIT

--- a/Roverfile
+++ b/Roverfile
@@ -1,0 +1,15 @@
+luarocks {
+
+  group { 'production' } {
+    -- module that does the actual ip range checks
+    module { 'lua-resty-iputils' },
+  },
+
+  group { 'development', 'test' } {
+    module { 'apicast' },
+    -- to be able to run repl as `require('resty.repl').start()`
+    module { 'lua-resty-repl' },
+    -- to automatically validate policy manifests
+    module { 'ljsonschema' },
+  }
+}

--- a/Roverfile.lock
+++ b/Roverfile.lock
@@ -1,0 +1,17 @@
+apicast scm-1|24922efe1780b3764a1978a8a17cc2dfbea50d70|development,test
+argparse 0.5.0-1||development,test
+inspect 3.1.1-0||development,test
+liquid 0.1.0-1||development,test
+ljsonschema 0.1.0-1||development,test
+lua-resty-env 0.4.0-1||development,test
+lua-resty-execvp 0.1.1-1||development,test
+lua-resty-http 0.12-0||development,test
+lua-resty-iputils 0.3.0-1||production
+lua-resty-jwt 0.1.11-0||development,test
+lua-resty-repl 0.0.6-0|3878f41b7e8f97b1c96919db19dbee9496569dda|development,test
+lua-resty-url 0.2.0-1||development,test
+luafilesystem 1.7.0-2||development,test
+net-url 0.9-1||development,test
+nginx-lua-prometheus 0.20171117-4||development,test
+penlight 1.5.4-1||development,test
+router 2.1-0||development,test

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,1 @@
+requires 'Test::APIcast', '0.11';

--- a/openshift.yml
+++ b/openshift.yml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: "apicast-private-ip-blacklist-policy"
+message: "APIcast Private IP Blacklist Policy"
+objects:
+
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+    labels:
+      app: apicast
+    name: apicast-policy
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+    labels:
+      app: apicast
+    name: apicast-private-ip-blacklist-policy
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: apicast-policy:private-ip-blacklist
+    source:
+      git:
+        uri: https://github.com/3scale/apicast-private-ip-blacklist-policy.git
+        ref: 'master'
+      type: Git
+    strategy:
+      type: Source
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'amp-apicast:${AMP_RELEASE}'
+
+- apiVersion: v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+    labels:
+      app: apicast
+    name: apicast-customized
+  spec:
+    nodeSelector: null
+    output:
+      to:
+        kind: ImageStreamTag
+        name: 'amp-apicast:latest'
+    postCommit:
+      args:
+        - '--test'
+        - '--lazy'
+      command:
+        - bin/apicast
+    resources: {}
+    runPolicy: Serial
+    source:
+      images:
+        - from:
+            kind: ImageStreamTag
+            name: 'apicast-policy:private-ip-blacklist'
+          paths:
+            # copy policy source code into the new image
+            - destinationDir: policies
+              sourcePath: /opt/app-root/src/policies/private-ip-blacklist
+            # copy also installed dependencies to the policy folder, so they are vendored
+            - destinationDir: policies/private-ip-blacklist/0.1/resty/
+              sourcePath: /opt/app-root/src/lua_modules/share/lua/5.1/resty/iputils.lua
+      type: Image
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: 'amp-apicast:${AMP_RELEASE}'
+      type: Source
+    triggers:
+      - type: ConfigChange
+      - type: ImageChange
+
+parameters:
+- name: AMP_RELEASE
+  required: true
+  description: AMP Version (eg. 2.2.0-GA)

--- a/policies/private-ip-blacklist/0.1/apicast-policy.json
+++ b/policies/private-ip-blacklist/0.1/apicast-policy.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://apicast.io/policy-v1/schema#manifest#",
+  "name": "Upstream Private IP blacklist",
+  "summary": "Deny connecting to private IP address ranges.",
+  "description": "Deny connecting to private IP address ranges.",
+  "version": "0.1",
+  "configuration": {
+    "type": "object",
+    "properties": { }
+  }
+}

--- a/policies/private-ip-blacklist/0.1/balancer_blacklist.lua
+++ b/policies/private-ip-blacklist/0.1/balancer_blacklist.lua
@@ -1,0 +1,84 @@
+local iputils = require("resty.iputils")
+local default_balancer = require('resty.balancer.round_robin').call
+local resty_balancer = require('resty.balancer')
+local split = require('ngx.re').split
+local setmetatable = setmetatable
+
+local _M = require('apicast.policy').new('Upstream Private IP Blacklist', '0.1')
+local mt = { __index = _M }
+
+local ipv4 = {
+  unspecified = { '0.0.0.0/8' },
+  broadcast = { '255.255.255.255/32' },
+  multicast = { '224.0.0.0/4' },
+  linkLocal = { '169.254.0.0/16' },
+  loopback = { '127.0.0.0/8' },
+  private = { '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16' },
+  reserved = { '192.0.0.0/24' }
+}
+
+local whitelist = iputils.parse_cidrs(split(os.getenv('APICAST_BALANCER_WHITELIST') or '', ','))
+local blacklist = {}
+
+for _,cidrs in pairs(ipv4) do
+  local list = iputils.parse_cidrs(cidrs)
+
+  for i=1,#list do
+    table.insert(blacklist, list[i])
+  end
+end
+
+function _M.new()
+  return setmetatable({}, mt)
+end
+
+function _M:init()
+  iputils.enable_lrucache()
+end
+
+local function whitelisted(ip)
+  local whitelisted = iputils.ip_in_cidrs(ip, whitelist)
+
+  if whitelisted then
+    return true
+  end
+
+  local blacklisted, err = iputils.ip_in_cidrs(ip, blacklist)
+
+  return not blacklisted, err
+end
+
+local balancer_with_blacklist = resty_balancer.new(function(peers)
+  local peer, i = default_balancer(peers)
+
+  if not peer then
+    return nil, i
+  end
+
+  local ip = peer[1]
+  local allowed, err = whitelisted(ip)
+
+  if not allowed then
+    return nil, 'blacklisted'
+  elseif err then
+    return nil, err
+  else
+    return peer, i
+  end
+end)
+
+function _M:balancer()
+  local balancer = balancer_with_blacklist
+  local host = ngx.var.proxy_host
+  local peers = balancer:peers(ngx.ctx[host])
+
+  local peer, err = balancer:set_peer(peers)
+
+  if not peer then
+    ngx.status = ngx.HTTP_SERVICE_UNAVAILABLE
+    ngx.log(ngx.ERR, "failed to set current backend peer: ", err)
+    ngx.exit(ngx.status)
+  end
+end
+
+return _M

--- a/policies/private-ip-blacklist/0.1/init.lua
+++ b/policies/private-ip-blacklist/0.1/init.lua
@@ -1,0 +1,1 @@
+return require('balancer_blacklist')

--- a/t/blacklist.t
+++ b/t/blacklist.t
@@ -1,0 +1,65 @@
+BEGIN {
+    $ENV{TEST_NGINX_APICAST_BINARY} ||= 'rover exec apicast';
+    $ENV{APICAST_POLICY_LOAD_PATH} = './policies';
+}
+
+use strict;
+use warnings FATAL => 'all';
+use Test::APIcast::Blackbox 'no_plan';
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: balancer blacklist
+The module does not crash without configuration.
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "private-ip-blacklist", "version": "0.1" },
+          { "name": "apicast.policy.echo", "configuration": { } }
+        ]
+      }
+    }
+  ]
+}
+--- request
+GET /t
+--- response_body
+GET /t HTTP/1.1
+--- error_code: 200
+--- no_error_log
+[error]
+
+
+
+=== TEST 2: balancer upstream blacklist
+Going to prevent connecting to local upstream.
+--- configuration
+{
+  "services": [
+    {
+      "proxy": {
+        "policy_chain": [
+          { "name": "private-ip-blacklist", "version": "0.1" },
+          { "name": "apicast.policy.upstream",
+            "configuration": { "rules": [ { "regex": "/", "url": "http://test" } ] }
+          }
+        ]
+      }
+    }
+  ]
+}
+--- upstream
+location /t {
+  content_by_lua_block { ngx.say('ok') }
+}
+--- request
+GET /t
+--- error_code: 503
+--- error_log
+failed to set current backend peer: blacklisted while connecting to upstream
+


### PR DESCRIPTION
This policy shows how to develop policies outside the main APIcast repository and then deploy them to OpenShift.

It has a CI set up to run the test suite.

Fixes https://issues.jboss.org/browse/THREESCALE-732